### PR TITLE
Okta Missing Config Item

### DIFF
--- a/docs/providers/okta.md
+++ b/docs/providers/okta.md
@@ -68,7 +68,8 @@ You will need to add an entry to the services configuration file so that after c
 'okta' => [
     'client_id' => env('OKTA_KEY'),
     'client_secret' => env('OKTA_SECRET'),
-    'redirect' => env('OKTA_REDIRECT_URI')
+    'redirect' => env('OKTA_REDIRECT_URI'),
+    'base_url' => env('OKTA_BASE_URL')
 ],
 ```
 


### PR DESCRIPTION
I think during the documentation migration we might have missed the extra parameter that is needed for Okta.

Okta is a bit of a weird one in that it **requires** the `base_url` in order to work (because every company has a different subdomain of Okta.