### PR TITLE
add link to about

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 ---
 home: true
+actionText: Get Started →
+actionLink: /about.html
 features:
 - title: Simplicity First
   details: Minimal setup with a familiar structure helps you focus on developing your newest product.


### PR DESCRIPTION
It's not immediately obvious where to go to see the providers available. Adding an action button could help with this.