### PR TITLE
Use correct driver name in Battle.net docs

### DIFF
--- a/docs/providers/battle-net.md
+++ b/docs/providers/battle-net.md
@@ -65,7 +65,7 @@ You will need to add an entry to the services configuration file so that after c
 #### Add to `config/services.php`.
 
 ```php
-'battle.net' => [
+'battlenet' => [
     'client_id' => env('BATTLE.NET_KEY'),
     'client_secret' => env('BATTLE.NET_SECRET'),
     'redirect' => env('BATTLE.NET_REDIRECT_URI')
@@ -79,7 +79,7 @@ You will need to add an entry to the services configuration file so that after c
 * You should now be able to use it like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('Battle.net')->redirect();
+return Socialite::with('battlenet')->redirect();
 ```
 
 ### Lumen Support
@@ -99,10 +99,10 @@ Also, configs cannot be parsed from the `services[]` in Lumen.  You can only set
 
 ```php
 // to turn off stateless
-return Socialite::with('Battle.net')->stateless(false)->redirect();
+return Socialite::with('battlenet')->stateless(false)->redirect();
 
 // to use stateless
-return Socialite::with('Battle.net')->stateless()->redirect();
+return Socialite::with('battlenet')->stateless()->redirect();
 ```
 
 ### Overriding a config
@@ -115,7 +115,7 @@ $clientSecret = "secret";
 $redirectUrl = "http://yourdomain.com/api/redirect";
 $additionalProviderConfig = ['site' => 'meta.stackoverflow.com'];
 $config = new \SocialiteProviders\Manager\Config($clientId, $clientSecret, $redirectUrl, $additionalProviderConfig);
-return Socialite::with('Battle.net')->setConfig($config)->redirect();
+return Socialite::with('battlenet')->setConfig($config)->redirect();
 ```
 
 ### Retrieving the Access Token Response Body
@@ -127,7 +127,7 @@ may contain items such as a `refresh_token`.
 You can get the access token response body, after you called the `user()` method in Socialite, by accessing the property `$user->accessTokenResponseBody`;
 
 ```php
-$user = Socialite::driver('Battle.net')->user();
+$user = Socialite::driver('battlenet')->user();
 $accessTokenResponseBody = $user->accessTokenResponseBody;
 ```
 


### PR DESCRIPTION
The real driver name is "battlenet" instead of "Battle.net". The old version of the docs will lead you into a not supported exception. This fixes the docs to refer to the correct driver identifier.