### PR TITLE
Fixed SalesForce driver name to lower case

### DIFF
--- a/docs/providers/sales-force.md
+++ b/docs/providers/sales-force.md
@@ -68,7 +68,8 @@ You will need to add an entry to the services configuration file so that after c
 'salesforce' => [
     'client_id' => env('SALESFORCE_KEY'),
     'client_secret' => env('SALESFORCE_SECRET'),
-    'redirect' => env('SALESFORCE_REDIRECT_URI')
+    'redirect' => env('SALESFORCE_REDIRECT_URI'),
+    'instance_url' => env('SALESFORCE_INSTANCE_URL'), // To login to the Sandbox, please specify https://test.salesforce.com
 ],
 ```
 
@@ -79,7 +80,7 @@ You will need to add an entry to the services configuration file so that after c
 * You should now be able to use it like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('SalesForce')->redirect();
+return Socialite::with('salesforce')->redirect();
 ```
 
 ### Lumen Support
@@ -99,10 +100,10 @@ Also, configs cannot be parsed from the `services[]` in Lumen.  You can only set
 
 ```php
 // to turn off stateless
-return Socialite::with('SalesForce')->stateless(false)->redirect();
+return Socialite::with('salesforce')->stateless(false)->redirect();
 
 // to use stateless
-return Socialite::with('SalesForce')->stateless()->redirect();
+return Socialite::with('salesforce')->stateless()->redirect();
 ```
 
 ### Overriding a config
@@ -115,7 +116,7 @@ $clientSecret = "secret";
 $redirectUrl = "http://yourdomain.com/api/redirect";
 $additionalProviderConfig = ['site' => 'meta.stackoverflow.com'];
 $config = new \SocialiteProviders\Manager\Config($clientId, $clientSecret, $redirectUrl, $additionalProviderConfig);
-return Socialite::with('SalesForce')->setConfig($config)->redirect();
+return Socialite::with('salesforce')->setConfig($config)->redirect();
 ```
 
 ### Retrieving the Access Token Response Body
@@ -127,7 +128,7 @@ may contain items such as a `refresh_token`.
 You can get the access token response body, after you called the `user()` method in Socialite, by accessing the property `$user->accessTokenResponseBody`;
 
 ```php
-$user = Socialite::driver('SalesForce')->user();
+$user = Socialite::driver('salesforce')->user();
 $accessTokenResponseBody = $user->accessTokenResponseBody;
 ```
 


### PR DESCRIPTION
The method

`Socialite::with('SalesForce')->redirect();`

is returning driver not supported error.

I fixed this and added a usage of instance_url.