### PR TITLE
Drivers are case sensitive

### DIFF
--- a/docs/providers/hub-spot.md
+++ b/docs/providers/hub-spot.md
@@ -79,7 +79,7 @@ You will need to add an entry to the services configuration file so that after c
 * You should now be able to use it like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('HubSpot')->redirect();
+return Socialite::with('hubspot')->redirect();
 ```
 
 ### Lumen Support
@@ -99,10 +99,10 @@ Also, configs cannot be parsed from the `services[]` in Lumen.  You can only set
 
 ```php
 // to turn off stateless
-return Socialite::with('HubSpot')->stateless(false)->redirect();
+return Socialite::with('hubspot')->stateless(false)->redirect();
 
 // to use stateless
-return Socialite::with('HubSpot')->stateless()->redirect();
+return Socialite::with('hubspot')->stateless()->redirect();
 ```
 
 ### Overriding a config
@@ -115,7 +115,7 @@ $clientSecret = "secret";
 $redirectUrl = "http://yourdomain.com/api/redirect";
 $additionalProviderConfig = ['site' => 'meta.stackoverflow.com'];
 $config = new \SocialiteProviders\Manager\Config($clientId, $clientSecret, $redirectUrl, $additionalProviderConfig);
-return Socialite::with('HubSpot')->setConfig($config)->redirect();
+return Socialite::with('hubspot')->setConfig($config)->redirect();
 ```
 
 ### Retrieving the Access Token Response Body
@@ -127,7 +127,7 @@ may contain items such as a `refresh_token`.
 You can get the access token response body, after you called the `user()` method in Socialite, by accessing the property `$user->accessTokenResponseBody`;
 
 ```php
-$user = Socialite::driver('HubSpot')->user();
+$user = Socialite::driver('hubspot')->user();
 $accessTokenResponseBody = $user->accessTokenResponseBody;
 ```
 


### PR DESCRIPTION
The camel case `with('HubSpot')` or `driver('HubSpot')` does not work.