### PR TITLE
Fix casing for Dropbox documentation #59

### DIFF
--- a/docs/providers/dropbox.md
+++ b/docs/providers/dropbox.md
@@ -79,7 +79,7 @@ You will need to add an entry to the services configuration file so that after c
 * You should now be able to use it like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('Dropbox')->redirect();
+return Socialite::with('dropbox')->redirect();
 ```
 
 ### Lumen Support
@@ -99,7 +99,7 @@ Also, configs cannot be parsed from the `services[]` in Lumen.  You can only set
 
 ```php
 // to turn off stateless
-return Socialite::with('Dropbox')->stateless(false)->redirect();
+return Socialite::with('dropbox')->stateless(false)->redirect();
 
 // to use stateless
 return Socialite::with('Dropbox')->stateless()->redirect();
@@ -115,7 +115,7 @@ $clientSecret = "secret";
 $redirectUrl = "http://yourdomain.com/api/redirect";
 $additionalProviderConfig = ['site' => 'meta.stackoverflow.com'];
 $config = new \SocialiteProviders\Manager\Config($clientId, $clientSecret, $redirectUrl, $additionalProviderConfig);
-return Socialite::with('Dropbox')->setConfig($config)->redirect();
+return Socialite::with('dropbox')->setConfig($config)->redirect();
 ```
 
 ### Retrieving the Access Token Response Body
@@ -127,7 +127,7 @@ may contain items such as a `refresh_token`.
 You can get the access token response body, after you called the `user()` method in Socialite, by accessing the property `$user->accessTokenResponseBody`;
 
 ```php
-$user = Socialite::driver('Dropbox')->user();
+$user = Socialite::driver('dropbox')->user();
 $accessTokenResponseBody = $user->accessTokenResponseBody;
 ```
 


### PR DESCRIPTION
Fixes for issue #59 where "Dropbox" doesn't work but "dropbox" does when initializing the Socialite::driver() function.

#59 