### PR TITLE
Add public key to the Odnoklassniki provider configuration

### DIFF
--- a/docs/providers/odnoklassniki.md
+++ b/docs/providers/odnoklassniki.md
@@ -67,6 +67,7 @@ You will need to add an entry to the services configuration file so that after c
 ```php
 'odnoklassniki' => [
     'client_id' => env('ODNOKLASSNIKI_KEY'),
+    'client_public' => env('ODNOKLASSNIKI_PUBLIC'),
     'client_secret' => env('ODNOKLASSNIKI_SECRET'),
     'redirect' => env('ODNOKLASSNIKI_REDIRECT_URI')
 ],


### PR DESCRIPTION
Odnoklassniki provider needs a public key. It's used in the "getUserByToken" method:

`$publicKey = app()['config']['services.odnoklassniki']['client_public'];`