### PR TITLE
Lowercases spotify provider key in Socialite calls

### DIFF
--- a/docs/providers/spotify.md
+++ b/docs/providers/spotify.md
@@ -79,7 +79,7 @@ You will need to add an entry to the services configuration file so that after c
 * You should now be able to use it like you would regularly use Socialite (assuming you have the facade installed):
 
 ```php
-return Socialite::with('Spotify')->redirect();
+return Socialite::with('spotify')->redirect();
 ```
 
 ### Lumen Support
@@ -99,10 +99,10 @@ Also, configs cannot be parsed from the `services[]` in Lumen.  You can only set
 
 ```php
 // to turn off stateless
-return Socialite::with('Spotify')->stateless(false)->redirect();
+return Socialite::with('spotify')->stateless(false)->redirect();
 
 // to use stateless
-return Socialite::with('Spotify')->stateless()->redirect();
+return Socialite::with('spotify')->stateless()->redirect();
 ```
 
 ### Overriding a config
@@ -115,7 +115,7 @@ $clientSecret = "secret";
 $redirectUrl = "http://yourdomain.com/api/redirect";
 $additionalProviderConfig = ['site' => 'meta.stackoverflow.com'];
 $config = new \SocialiteProviders\Manager\Config($clientId, $clientSecret, $redirectUrl, $additionalProviderConfig);
-return Socialite::with('Spotify')->setConfig($config)->redirect();
+return Socialite::with('spotify')->setConfig($config)->redirect();
 ```
 
 ### Retrieving the Access Token Response Body
@@ -127,7 +127,7 @@ may contain items such as a `refresh_token`.
 You can get the access token response body, after you called the `user()` method in Socialite, by accessing the property `$user->accessTokenResponseBody`;
 
 ```php
-$user = Socialite::driver('Spotify')->user();
+$user = Socialite::driver('spotify')->user();
 $accessTokenResponseBody = $user->accessTokenResponseBody;
 ```
 


### PR DESCRIPTION
After trying to hook up the Spotify authentication using the provider, I was getting an error kicked back that the provider couldn't be found. Using a lowercase `spotify` instead of the current `Spotify` on the documentation allowed it to proceed as intended.